### PR TITLE
Added 'registration' to JINGO_EXCLUDE_APPS. 

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -216,6 +216,7 @@ FILE_UPLOAD_PERMISSIONS = 0664
 # apps here:
 JINGO_EXCLUDE_APPS = [
     'admin',
+    'registration',
     'debug_toolbar',
     'debug_toolbar_user_panel',
     'memcache_toolbar',


### PR DESCRIPTION
This change fixes a "TemplateSyntaxError at /admin/logout/". See: http://github.com/mozilla/playdoh/pull/103

P.S. nice project template! :-)
