### PR TITLE
fix local jquery fall back url

### DIFF
--- a/base/templates/_layouts/base.html
+++ b/base/templates/_layouts/base.html
@@ -62,7 +62,7 @@
 
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.9.1.min.js"><\/script>')</script>
+  <script>window.jQuery || document.write('<script src="{{ STATIC_URL }}js/libs/jquery-1.9.1.min.js"><\/script>')</script>
 
   <!-- scripts concatenated and minified via django-compressor -->
   {% compress js %}


### PR DESCRIPTION
The local jquery fall back url seems not correct with the folder "vendor", change it to the actual local path
