### PR TITLE
django-compressor has Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ All the code provided in the template itself is compatable with Python 3. Unfort
 
 The libraries I am aware of that do not support Python 3:
 
-* django-compressor
 * python-memcached (use python3-memcached)
 
 {% endif %}


### PR DESCRIPTION
thus removing it from the Python 3 notes